### PR TITLE
make jackson-module-kotlin an api dependency as there are many classe…

### DIFF
--- a/platform-spring-bom/platform-spring-json/build.gradle
+++ b/platform-spring-bom/platform-spring-json/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     api('com.fasterxml.jackson.core:jackson-annotations')
     api('com.fasterxml.jackson.core:jackson-databind')
 
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
+    api('com.fasterxml.jackson.module:jackson-module-kotlin')
 
-    implementation 'org.springframework.boot:spring-boot-starter-json'
+    implementation('org.springframework.boot:spring-boot-starter-json')
 }


### PR DESCRIPTION
…s in there that might be used at compile time