### PR TITLE
Kotlin data classes are final, nevertheless they can be deserialized …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects { p ->
 
     group "io.cloudflight.platform.spring"
     description "Cloudflight Platform for Spring Boot"
-    version "1.1.1"
+    version "1.1.2"
 
     repositories {
         mavenCentral()

--- a/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/autoconfigure/CachingAutoConfiguration.kt
+++ b/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/autoconfigure/CachingAutoConfiguration.kt
@@ -118,7 +118,7 @@ class CachingAutoConfiguration {
 
             objectMapper.activateDefaultTyping(
                 objectMapper.polymorphicTypeValidator,
-                ObjectMapper.DefaultTyping.NON_FINAL,
+                ObjectMapper.DefaultTyping.EVERYTHING,
                 JsonTypeInfo.As.PROPERTY
             )
 

--- a/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/autoconfigure/CachingAutoConfiguration.kt
+++ b/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/autoconfigure/CachingAutoConfiguration.kt
@@ -111,7 +111,7 @@ class CachingAutoConfiguration {
         private val JSON = createJsonSerializer()
         private val LOG = KotlinLogging.logger { }
 
-        private fun createJsonSerializer(): GenericJackson2JsonRedisSerializer {
+        internal fun createJsonSerializer(): GenericJackson2JsonRedisSerializer {
             val objectMapper = ObjectMapperFactory
                 .createObjectMapper()
                 .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)

--- a/platform-spring-bom/platform-spring-caching/src/test/kotlin/io/cloudflight/platform/spring/caching/CachingAutoConfigurationTest.kt
+++ b/platform-spring-bom/platform-spring-caching/src/test/kotlin/io/cloudflight/platform/spring/caching/CachingAutoConfigurationTest.kt
@@ -1,0 +1,19 @@
+package io.cloudflight.platform.spring.caching
+
+import io.cloudflight.platform.spring.caching.autoconfigure.CachingAutoConfiguration
+import org.junit.jupiter.api.Test
+
+class CachingAutoConfigurationTest {
+    @Test
+    fun testRedisTypeInfoSerialization() {
+        val serializer = CachingAutoConfiguration.createJsonSerializer()
+
+        val data = DataDto("foo")
+        val bytes = serializer.serialize(data)
+        val obj = serializer.deserialize(bytes, java.lang.Object::class.java) as DataDto
+
+        assert(data.foo == obj.foo)
+    }
+}
+
+data class DataDto(var foo: String)


### PR DESCRIPTION
…with the help of jackson-module-kotlin. In order to do so type information always has to be serialized to the redis cache.