### PR TITLE
issue #41 property management.server.port is only set when not set explicitly

### DIFF
--- a/platform-spring-bom/platform-spring-monitoring/src/main/kotlin/io/cloudflight/platform/spring/monitoring/autoconfigure/ManagementSecurityAutoConfiguration.kt
+++ b/platform-spring-bom/platform-spring-monitoring/src/main/kotlin/io/cloudflight/platform/spring/monitoring/autoconfigure/ManagementSecurityAutoConfiguration.kt
@@ -57,18 +57,24 @@ class ManagementServerPortEnvironmentPostProcessor : EnvironmentPostProcessor {
         ) {
             // we do not change the port for the management services in test cases and container tests to not get any conflicts
             // with concurrent builds
-            (environment.getProperty("server.port") ?: SPRING_DEFAULT_PORT).let { serverPort ->
-                environment.propertySources.addFirst(
-                    MapPropertySource(
-                        "cloudflight-management",
-                        mapOf("management.server.port" to serverPort.toInt() + 10000)
+            (environment.getProperty(SERVER_PORT_NAME) ?: SPRING_DEFAULT_PORT).let { serverPort ->
+                if (environment.getProperty(MANAGEMENT_SERVER_PORT_NAME).isNullOrBlank()) {
+                    // only change unless already set
+                    environment.propertySources.addFirst(
+                        MapPropertySource(
+                            "cloudflight-management",
+                            mapOf(MANAGEMENT_SERVER_PORT_NAME to serverPort.toInt() + 10000)
+                        )
                     )
-                )
+                }
             }
         }
     }
 
     companion object {
         const val SPRING_DEFAULT_PORT = "8080"
+
+        const val SERVER_PORT_NAME = "server.port"
+        const val MANAGEMENT_SERVER_PORT_NAME = "management.server.port"
     }
 }

--- a/platform-spring-bom/platform-spring-monitoring/src/test/kotlin/io/cloudflight/platform/spring/monitoring/autoconfigure/ManagementServerPortEnvironmentPostProcessorTest.kt
+++ b/platform-spring-bom/platform-spring-monitoring/src/test/kotlin/io/cloudflight/platform/spring/monitoring/autoconfigure/ManagementServerPortEnvironmentPostProcessorTest.kt
@@ -1,0 +1,44 @@
+package io.cloudflight.platform.spring.monitoring.autoconfigure
+
+import io.cloudflight.platform.spring.monitoring.autoconfigure.ManagementServerPortEnvironmentPostProcessor.Companion.MANAGEMENT_SERVER_PORT_NAME
+import io.cloudflight.platform.spring.monitoring.autoconfigure.ManagementServerPortEnvironmentPostProcessor.Companion.SERVER_PORT_NAME
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import org.springframework.boot.SpringApplication
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.MutablePropertySources
+import org.springframework.core.env.Profiles
+
+class ManagementServerPortEnvironmentPostProcessorTest {
+
+    @Test
+    fun noExplicitManagementServerPortOverride() {
+        val env = mockk<ConfigurableEnvironment>()
+
+        every { env.acceptsProfiles(any() as Profiles) }.returns(false)
+        every { env.getProperty(SERVER_PORT_NAME) }.returns("1024")
+        every { env.getProperty(MANAGEMENT_SERVER_PORT_NAME) }.returns("1025")
+        val propertySources=mockk<MutablePropertySources>()
+        every { env.propertySources }.returns(propertySources)
+
+        ManagementServerPortEnvironmentPostProcessor().postProcessEnvironment(env, SpringApplication())
+
+        verify (exactly = 0){ propertySources.addFirst(any()) }
+    }
+
+    @Test
+    fun deriveManagementServerPortFromServerPort() {
+        val env = mockk<ConfigurableEnvironment>(relaxed = true)
+
+        every { env.acceptsProfiles(any() as Profiles) }.returns(false)
+        every { env.getProperty(SERVER_PORT_NAME) }.returns("1024")
+        every { env.getProperty(MANAGEMENT_SERVER_PORT_NAME) }.returns(null)
+        val propertySources=mockk<MutablePropertySources>()
+        every { env.propertySources }.returns(propertySources)
+        justRun { propertySources.addFirst(any()) }
+
+        ManagementServerPortEnvironmentPostProcessor().postProcessEnvironment(env, SpringApplication())
+
+        verify (exactly = 1){ propertySources.addFirst(any()) }
+    }
+}


### PR DESCRIPTION
Previously any explicitly set `management.server.port` property was ignored and over written by `server.port + 10.000`.
This is now handled properly.

However in case someone had set the `management.server.port` property this is now no longer ignored and may have an impact to running existing systems.