### PR TITLE
patch: limit dependency of conditionals to smallest scope in caching

### DIFF
--- a/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/EvictCacheErrorHandler.kt
+++ b/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/EvictCacheErrorHandler.kt
@@ -5,7 +5,7 @@ import org.springframework.cache.Cache
 import org.springframework.cache.interceptor.SimpleCacheErrorHandler
 import org.springframework.data.redis.serializer.SerializationException
 
-class RedisCacheErrorHandler : SimpleCacheErrorHandler() {
+class EvictCacheErrorHandler : SimpleCacheErrorHandler() {
     override fun handleCacheGetError(exception: RuntimeException, cache: Cache, key: Any) {
         if (exception is SerializationException) {
             LOG.error("SerializationException during (de)serialization of value with key '$key' at cache ${cache.name} " +
@@ -17,6 +17,6 @@ class RedisCacheErrorHandler : SimpleCacheErrorHandler() {
     }
 
     companion object {
-        private val LOG = LoggerFactory.getLogger(RedisCacheErrorHandler::class.java)
+        private val LOG = LoggerFactory.getLogger(EvictCacheErrorHandler::class.java)
     }
 }

--- a/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/autoconfigure/CachingAutoConfiguration.kt
+++ b/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/autoconfigure/CachingAutoConfiguration.kt
@@ -3,6 +3,7 @@ package io.cloudflight.platform.spring.caching.autoconfigure
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.cloudflight.platform.spring.caching.RedisCacheErrorHandler
 import io.cloudflight.platform.spring.json.ObjectMapperFactory
 import mu.KotlinLogging
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -30,17 +31,25 @@ import java.time.Duration
 
 @AutoConfiguration(before = [RedisAutoConfiguration::class])
 @EnableCaching(order = 1000)
-@Import(CachingAutoConfiguration.RedisConfiguration::class)
+@Import(
+    CachingAutoConfiguration.RedisConfiguration::class,
+    CachingAutoConfiguration.RedisCachingConfigurerConfiguration::class
+)
 class CachingAutoConfiguration {
 
     @Configuration
     @ConditionalOnClass(RedisOperations::class)
     @ConditionalOnBean(RedisConnectionFactory::class)
-    class RedisConfiguration : CachingConfigurer {
+    class RedisCachingConfigurerConfiguration : CachingConfigurer {
         @Bean
         override fun errorHandler(): CacheErrorHandler {
-            return io.cloudflight.platform.spring.caching.RedisCacheErrorHandler()
+            return RedisCacheErrorHandler()
         }
+    }
+
+    @Configuration
+    @ConditionalOnClass(RedisOperations::class)
+    class RedisConfiguration {
 
         @Bean
         fun cacheConfiguration(cacheProperties: CacheProperties): RedisCacheConfiguration {

--- a/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/autoconfigure/CachingAutoConfiguration.kt
+++ b/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/autoconfigure/CachingAutoConfiguration.kt
@@ -3,19 +3,15 @@ package io.cloudflight.platform.spring.caching.autoconfigure
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.cloudflight.platform.spring.caching.RedisCacheErrorHandler
 import io.cloudflight.platform.spring.json.ObjectMapperFactory
 import mu.KotlinLogging
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.cache.CacheProperties
 import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
-import org.springframework.cache.annotation.CachingConfigurer
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cache.interceptor.CacheErrorHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
@@ -31,22 +27,8 @@ import java.time.Duration
 
 @AutoConfiguration(before = [RedisAutoConfiguration::class])
 @EnableCaching(order = 1000)
-@Import(
-    CachingAutoConfiguration.RedisConfiguration::class,
-    CachingAutoConfiguration.RedisCachingConfigurerConfiguration::class
-)
+@Import(CachingAutoConfiguration.RedisConfiguration::class)
 class CachingAutoConfiguration {
-
-    @Configuration
-    @ConditionalOnClass(RedisOperations::class)
-    @ConditionalOnBean(RedisConnectionFactory::class)
-    class RedisCachingConfigurerConfiguration : CachingConfigurer {
-        @Bean
-        override fun errorHandler(): CacheErrorHandler {
-            return RedisCacheErrorHandler()
-        }
-    }
-
     @Configuration
     @ConditionalOnClass(RedisOperations::class)
     class RedisConfiguration {

--- a/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/autoconfigure/CachingConfigurerAutoConfiguration.kt
+++ b/platform-spring-bom/platform-spring-caching/src/main/kotlin/io/cloudflight/platform/spring/caching/autoconfigure/CachingConfigurerAutoConfiguration.kt
@@ -1,0 +1,31 @@
+package io.cloudflight.platform.spring.caching.autoconfigure
+
+import io.cloudflight.platform.spring.caching.EvictCacheErrorHandler
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.cache.annotation.CachingConfigurer
+import org.springframework.cache.interceptor.CacheErrorHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Role
+import org.springframework.data.redis.core.RedisOperations
+
+@AutoConfiguration
+@ConditionalOnClass(RedisOperations::class)
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+@Import(CachingConfigurerAutoConfiguration.CachingConfigurerConfiguration::class)
+class CachingConfigurerAutoConfiguration {
+    @Configuration
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    class CachingConfigurerConfiguration : CachingConfigurer {
+        @Bean
+        // https://github.com/spring-projects/spring-security/issues/14209#issuecomment-1836854767
+        // @Role annotation does not propagate so it is required to be on all Beans in this file
+        @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+        override fun errorHandler(): CacheErrorHandler {
+            return EvictCacheErrorHandler()
+        }
+    }
+}

--- a/platform-spring-bom/platform-spring-caching/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/platform-spring-bom/platform-spring-caching/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 io.cloudflight.platform.spring.caching.autoconfigure.CachingAutoConfiguration
 io.cloudflight.platform.spring.caching.autoconfigure.SessionAutoConfiguration
+io.cloudflight.platform.spring.caching.autoconfigure.CachingConfigurerAutoConfiguration

--- a/platform-spring-bom/platform-spring-caching/src/test/kotlin/io/cloudflight/platform/spring/caching/CachingConfigurerAutoConfigurationTest.kt
+++ b/platform-spring-bom/platform-spring-caching/src/test/kotlin/io/cloudflight/platform/spring/caching/CachingConfigurerAutoConfigurationTest.kt
@@ -1,0 +1,47 @@
+package io.cloudflight.platform.spring.caching
+
+import io.cloudflight.platform.spring.caching.autoconfigure.CachingConfigurerAutoConfiguration
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.interceptor.CacheErrorHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+
+
+class CachingConfigurerAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(CachingConfigurerAutoConfiguration::class.java))
+
+    @Test
+    fun cacheErrorHandlerBean() {
+        this.contextRunner.withUserConfiguration(BasicRedisConfiguration::class.java)
+            .run { context ->
+                assertThat(context).hasSingleBean(CacheErrorHandler::class.java)
+                assertThat(context).getBean("errorHandler")
+                    .isSameAs(context.getBean(CacheErrorHandler::class.java))
+            }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableCaching
+    private class BasicRedisConfiguration {
+
+        @Bean
+        fun redisConnectionFactory(): RedisConnectionFactory {
+            return mock(RedisConnectionFactory::class.java)
+        }
+
+        @Bean
+        fun cacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
+            return RedisCacheManager.create(connectionFactory)
+        }
+    }
+}

--- a/platform-spring-bom/platform-spring-caching/src/test/kotlin/io/cloudflight/platform/spring/caching/EvictCacheErrorHandlerTest.kt
+++ b/platform-spring-bom/platform-spring-caching/src/test/kotlin/io/cloudflight/platform/spring/caching/EvictCacheErrorHandlerTest.kt
@@ -1,0 +1,107 @@
+package io.cloudflight.platform.spring.caching
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.willThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.CacheConfig
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.cache.annotation.CachingConfigurer
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.interceptor.CacheErrorHandler
+import org.springframework.cache.support.SimpleCacheManager
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.serializer.SerializationException
+import java.util.concurrent.atomic.AtomicLong
+
+
+class EvictCacheErrorHandlerTest {
+
+    private var context: AnnotationConfigApplicationContext? = null
+
+    private var cache: Cache? = null
+
+    private var errorHandler: CacheErrorHandler? = null
+
+    private var simpleService: SimpleService? = null
+
+
+    @BeforeEach
+    fun setup() {
+        this.context = AnnotationConfigApplicationContext(Config::class.java)
+        this.cache = context!!.getBean("mockCache", Cache::class.java)
+        this.errorHandler = context!!.getBean(CacheErrorHandler::class.java)
+        this.simpleService = context!!.getBean(SimpleService::class.java)
+    }
+
+
+    @AfterEach
+    fun closeContext() {
+        context!!.close()
+    }
+
+    @Test
+    fun getFail() {
+        val exception = SerializationException("Deserialization exception")
+        willThrow(exception).given(this.cache)!!.get(0L)
+
+        simpleService!!.get(0L)
+        verify(this.cache!!).get(0L)
+        verify(this.cache!!).evict(0L) // result of the invocation
+    }
+
+    @Test
+    fun getFailException() {
+        val exception = IllegalStateException("Wrong type exception")
+        willThrow(exception).given(this.cache)!!.get(0L)
+
+        assertThrows<IllegalStateException> { simpleService!!.get(0L) }
+        verify(this.cache)!!.get(0L)
+    }
+
+    @Configuration
+    @EnableCaching
+    class Config : CachingConfigurer {
+        @Bean
+        override fun errorHandler(): CacheErrorHandler {
+            return EvictCacheErrorHandler()
+        }
+
+        @Bean
+        fun simpleService(): SimpleService {
+            return SimpleService()
+        }
+
+        @Bean
+        override fun cacheManager(): CacheManager {
+            val cacheManager = SimpleCacheManager()
+            cacheManager.setCaches(listOf(mockCache()))
+            return cacheManager
+        }
+
+        @Bean
+        fun mockCache(): Cache {
+            val cache: Cache = mock()
+            given(cache.name).willReturn("test")
+            return cache
+        }
+    }
+
+    @CacheConfig(cacheNames = ["test"])
+    open class SimpleService {
+        private val counter = AtomicLong()
+
+        @Cacheable
+        open fun get(id: Long): Any {
+            return counter.getAndIncrement()
+        }
+    }
+}


### PR DESCRIPTION
In the caching module we refactored the conditionals to limit the auto configuration. Due to this the implementation of the CachingConfigurer (to get a custom CacheErrorHandler) needed a dependency on RedisConnectionFactory or else it wouldn't be able to be post processed (due to the CachingConfigurer being needed in a MeterRegistryAutoConfiguration). 
This PR limits the dependency on RedisConnectionFactory to the CachingConfigurer and thus makes it easier for Spring to instantiate the beans.