### PR TITLE
fix: application not starting due to wrong usage of loggerContext

### DIFF
--- a/platform-spring-bom/platform-spring-logging-server-config/src/main/java/com/latch/LengthSplittingAppender.java
+++ b/platform-spring-bom/platform-spring-logging-server-config/src/main/java/com/latch/LengthSplittingAppender.java
@@ -34,13 +34,6 @@ import java.util.Map;
  * SOFTWARE.
  */
 public class LengthSplittingAppender extends SplittingAppenderBase<ILoggingEvent> {
-    private final LoggingEventCloner loggingEventCloner;
-
-    public LengthSplittingAppender() {
-        super();
-        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-        this.loggingEventCloner = new LoggingEventCloner(loggerContext);
-    }
 
     private int maxLength;
     private String sequenceKey;
@@ -76,7 +69,7 @@ public class LengthSplittingAppender extends SplittingAppenderBase<ILoggingEvent
             Map<String, String> seqMDCPropertyMap = new HashMap<>(event.getMDCPropertyMap());
             seqMDCPropertyMap.put(getSequenceKey(), Integer.toString(i));
 
-            LoggingEvent clonedEvent = loggingEventCloner.clone(event, message, seqMDCPropertyMap);
+            LoggingEvent clonedEvent = LoggingEventCloner.clone(event, message, seqMDCPropertyMap);
 
             splitLogEvents.add(clonedEvent);
         }

--- a/platform-spring-bom/platform-spring-logging-server-config/src/main/java/com/latch/LoggingEventCloner.java
+++ b/platform-spring-bom/platform-spring-logging-server-config/src/main/java/com/latch/LoggingEventCloner.java
@@ -3,6 +3,7 @@ package com.latch;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
+import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 
 import java.util.List;
@@ -32,20 +33,16 @@ import java.util.Map;
  * SOFTWARE.
  */
 class LoggingEventCloner {
-    private final LoggerContext loggerContext;
+    private static LoggerContext loggerContext;
 
-    public LoggingEventCloner(LoggerContext loggerContext) {
-        this.loggerContext = loggerContext;
-    }
-
-    public LoggingEvent clone(ILoggingEvent event, String message, Map<String, String> mdcValueMap) {
+    public static LoggingEvent clone(ILoggingEvent event, String message, Map<String, String> mdcValueMap) {
         LoggingEvent newEvent = new LoggingEvent();
 
         newEvent.setLevel(event.getLevel());
         newEvent.setLoggerName(event.getLoggerName());
         newEvent.setTimeStamp(event.getTimeStamp());
         newEvent.setLoggerContextRemoteView(event.getLoggerContextVO());
-        newEvent.setLoggerContext(this.loggerContext);
+        newEvent.setLoggerContext(getLoggerContext());
         newEvent.setThreadName(event.getThreadName());
         newEvent.setMessage(message);
         newEvent.setMDCPropertyMap(mdcValueMap);
@@ -60,5 +57,16 @@ class LoggingEventCloner {
         }
 
         return newEvent;
+    }
+
+    /**
+     * We can't set the logger context directly because that would cause issues if the logger context is not initialized yet.
+     */
+    private static LoggerContext getLoggerContext() {
+        if (loggerContext == null) {
+            loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        }
+
+        return loggerContext;
     }
 }

--- a/platform-spring-bom/platform-spring-logging-server-config/src/test/java/com/latch/LoggingEventClonerTest.java
+++ b/platform-spring-bom/platform-spring-logging-server-config/src/test/java/com/latch/LoggingEventClonerTest.java
@@ -13,14 +13,6 @@ import java.util.Collections;
 import java.util.Map;
 
 public class LoggingEventClonerTest {
-    private final LoggerContext loggerContext;
-    private final LoggingEventCloner loggingEventCloner;
-
-    public LoggingEventClonerTest() {
-        this.loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-        this.loggingEventCloner = new LoggingEventCloner(loggerContext);
-    }
-
     @Test
     public void correctlyClonesBasicEventProperties() {
         LoggingEvent event = createLoggingEventWithContext();
@@ -29,7 +21,7 @@ public class LoggingEventClonerTest {
         event.setThreadName("testThread");
         event.setTimeStamp(System.currentTimeMillis());
 
-        LoggingEvent clonedEvent = loggingEventCloner.clone(event, "", Collections.emptyMap());
+        LoggingEvent clonedEvent = LoggingEventCloner.clone(event, "", Collections.emptyMap());
 
         Assertions.assertNotNull(clonedEvent);
         Assertions.assertEquals(event.getLevel(), clonedEvent.getLevel());
@@ -43,7 +35,7 @@ public class LoggingEventClonerTest {
         LoggingEvent event = createLoggingEventWithContext();
         String message = "Test message";
 
-        LoggingEvent clonedEvent = loggingEventCloner.clone(event, message, Collections.emptyMap());
+        LoggingEvent clonedEvent = LoggingEventCloner.clone(event, message, Collections.emptyMap());
 
         Assertions.assertNotNull(clonedEvent);
         Assertions.assertEquals(message, clonedEvent.getMessage());
@@ -54,7 +46,7 @@ public class LoggingEventClonerTest {
         LoggingEvent event = createLoggingEventWithContext();
         Map<String, String> mdcProperties = Map.of("key1", "value1", "key2", "value2");
 
-        LoggingEvent clonedEvent = loggingEventCloner.clone(event, "", mdcProperties);
+        LoggingEvent clonedEvent = LoggingEventCloner.clone(event, "", mdcProperties);
 
         Assertions.assertNotNull(clonedEvent);
         Map<String, String> clonedMDCProperties = clonedEvent.getMDCPropertyMap();
@@ -69,7 +61,7 @@ public class LoggingEventClonerTest {
         Marker marker = new BasicMarkerFactory().getMarker("TestMarker");
         event.addMarker(marker);
 
-        LoggingEvent clonedEvent = loggingEventCloner.clone(event, "", Collections.emptyMap());
+        LoggingEvent clonedEvent = LoggingEventCloner.clone(event, "", Collections.emptyMap());
 
         Assertions.assertNotNull(clonedEvent);
         Assertions.assertEquals(marker.getName(), clonedEvent.getMarkerList().get(0).getName());
@@ -83,7 +75,7 @@ public class LoggingEventClonerTest {
         };
         event.setCallerData(callerData);
 
-        LoggingEvent clonedEvent = loggingEventCloner.clone(event, "", Collections.emptyMap());
+        LoggingEvent clonedEvent = LoggingEventCloner.clone(event, "", Collections.emptyMap());
 
         Assertions.assertTrue(clonedEvent.hasCallerData());
         StackTraceElement[] clonedCallerData = clonedEvent.getCallerData();
@@ -93,6 +85,7 @@ public class LoggingEventClonerTest {
 
     private LoggingEvent createLoggingEventWithContext() {
         LoggingEvent event = new LoggingEvent();
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
         event.setLoggerContext(loggerContext);
         return event;
     }

--- a/platform-spring-bom/platform-spring-logging-server-config/src/test/java/io/cloudflight/platform/spring/logging/LoggingJsonSplitterTest.java
+++ b/platform-spring-bom/platform-spring-logging-server-config/src/test/java/io/cloudflight/platform/spring/logging/LoggingJsonSplitterTest.java
@@ -49,7 +49,7 @@ public class LoggingJsonSplitterTest {
     }
 
     @Test
-    void logLongMessageWithJsonSplitterFails() {
+    void logLongMessageWithJsonSplitterDoesNotFail() {
         Assertions.assertDoesNotThrow(() -> LOG.info(TEST_MARKER, "This is a long message. ".repeat(1000)));
     }
 }


### PR DESCRIPTION
My previous "fix" in #146  actually breaks application startup if used in a kubernetes Context.

During startup the loggerContext is not yet initialised and the `(LoggerContext) LoggerFactory.getILoggerFactory()` call returns a SubstituteLoggerFactory which breaks when trying to cast to a LoggerContext.

I tried to replicate the Environment in a test but i could not find a good solution even with [junit-pioneer](https://github.com/junit-pioneer/junit-pioneer) or [system-stubs](github.com/webcompere/system-stubs)